### PR TITLE
Elastica integration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,9 +41,9 @@ unit-config: &unit-config
     # Download and cache dependencies
     - restore_cache:
         keys:
-        - v1-dependencies-{{ checksum "composer.json" }}
-        # fallback to using the latest cache if no exact match is found
-        - v1-dependencies-
+          - v1-dependencies-{{ checksum "composer.json" }}
+          # fallback to using the latest cache if no exact match is found
+          - v1-dependencies-
 
     - run:
         name: Install composer packages
@@ -141,6 +141,8 @@ jobs:
         environment:
           POSTGRES_PASSWORD: pgsql
           POSTGRES_USER: postgres
+      - image: redis:4.0
+      - image: elasticsearch:6.8.0
     steps:
       - checkout
       - run:
@@ -185,6 +187,11 @@ jobs:
           name: Install pcntl extension
           command: sudo docker-php-ext-install pcntl
       - run:
+          name: Install redis extension
+          command: |
+            sudo pecl install redis
+            sudo docker-php-ext-enable redis
+      - run:
           name: Curl test
           command: tests/integration/curl/test.sh
       - run:
@@ -210,6 +217,12 @@ jobs:
       - run:
           name: Wordpress test
           command: tests/integration/wordpress/test.sh
+      - run:
+          name: Predis test
+          command: tests/integration/predis/test.sh
+      - run:
+          name: Elastica test
+          command: tests/integration/elastica/test.sh
     environment:
       DB_HOST: 127.0.0.1
       DB_USERNAME: mysql

--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,7 @@
         "twig/twig": "~2.0 || ~1.35",
         "symfony/yaml": "~3.3",
         "guzzlehttp/guzzle": "~5.3",
+        "ruflin/elastica": "6.0.2",
         "predis/predis": "1.1.0",
         "guzzlehttp/psr7": "~1.4"
     },

--- a/src/Trace/Integrations/Elastica.php
+++ b/src/Trace/Integrations/Elastica.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * Copyright 2019 OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenCensus\Trace\Integrations;
+
+use OpenCensus\Trace\Span;
+
+/**
+ * This class handles instrumenting ElasticSearch requests with elastica using the opencensus extension.
+ *
+ * Example:
+ * ```
+ * use OpenCensus\Trace\Integrations\Elastica;
+ *
+ * Elastica::load();
+ * ```
+ */
+class Elastica implements IntegrationInterface
+{
+    /**
+     * Static method to add instrumentation to elasticsearch requests
+     */
+    public static function load()
+    {
+        if (!extension_loaded('opencensus')) {
+            trigger_error('opencensus extension required to load Elastica integrations.', E_USER_WARNING);
+        }
+
+        opencensus_trace_method('Elastica\Client', '__construct', [static::class, 'handleConstruct']);
+
+        opencensus_trace_method('Elastica\Client', 'request', [static::class, 'handleRequest']);
+    }
+
+    /**
+     * @param $elastica
+     * @param $config
+     *
+     * @return array
+     */
+    public static function handleConstruct($elastica, $config)
+    {
+        $attributes = [];
+        foreach ($config as $key => $param) {
+            $attributes[$key] = $param;
+        }
+
+        return [
+            'attributes' => $attributes,
+            'kind' => Span::KIND_CLIENT,
+        ];
+    }
+
+    /**
+     * @param $elastica
+     * @param $path
+     * @param $method
+     * @param $data
+     * @param $query
+     *
+     * @return array
+     */
+    public static function handleRequest($elastica, $path, $method, $data, $query)
+    {
+        return [
+            'attributes' => [
+                'path' => $path,
+                'method' => $method,
+                'data' => json_encode($data),
+                'query' => json_encode($query),
+            ],
+            'kind' => Span::KIND_CLIENT,
+        ];
+    }
+}

--- a/tests/integration/elastica/composer.json
+++ b/tests/integration/elastica/composer.json
@@ -1,0 +1,17 @@
+{
+    "require": {
+        "php": "^7.2",
+        "opencensus/opencensus": "dev-master",
+        "ruflin/elastica": "6.0.2",
+        "ext-opencensus": "*"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^7.0"
+    },
+    "repositories": [
+        {
+            "type": "git",
+            "url": "https://github.com/beatlabs/opencensus-php"
+        }
+    ]
+}

--- a/tests/integration/elastica/phpunit.xml.dist
+++ b/tests/integration/elastica/phpunit.xml.dist
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="./vendor/autoload.php" colors="true">
+  <testsuites>
+    <testsuite name="elastica">
+      <directory>tests</directory>
+    </testsuite>
+  </testsuites>
+  <filter>
+    <whitelist>
+      <directory suffix=".php">src</directory>
+    </whitelist>
+  </filter>
+</phpunit>

--- a/tests/integration/elastica/test.sh
+++ b/tests/integration/elastica/test.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Copyright 2018 OpenCensus Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+pushd $(dirname ${BASH_SOURCE[0]})
+source ../setup_test_repo.sh
+env
+
+sed -i "s|dev-master|dev-${BRANCH}|" composer.json
+sed -i "s|https://github.com/beatlabs/opencensus-php|${REPO}|" composer.json
+composer install -n --prefer-dist
+
+vendor/bin/phpunit
+
+popd

--- a/tests/integration/elastica/tests/ElasticaTest.php
+++ b/tests/integration/elastica/tests/ElasticaTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace OpenCensus\Tests\Integration\Trace\Exporter;
+
+use Elastica\Client;
+use Elastica\Request;
+use Elastica\Response;
+use OpenCensus\Trace\Integrations\Elastica;
+use OpenCensus\Trace\Tracer;
+use OpenCensus\Trace\Exporter\ExporterInterface;
+use PHPUnit\Framework\TestCase;
+
+class ElasticaTest extends TestCase
+{
+    private $tracer;
+    private static $elasticHost;
+    private static $elasticPort;
+
+    public static function setUpBeforeClass()
+    {
+        Elastica::load();
+        self::$elasticHost = getenv('ELASTIC_HOST') ?: '127.0.0.1';
+        self::$elasticPort = (int) (getenv('ELASTIC_PORT') ?: 9200);
+    }
+
+    public function setUp()
+    {
+        if (!extension_loaded('opencensus')) {
+            $this->markTestSkipped('Please enable the opencensus extension.');
+        }
+        opencensus_trace_clear();
+        $exporter = $this->prophesize(ExporterInterface::class);
+        $this->tracer = Tracer::start($exporter->reveal(), [
+            'skipReporting' => true
+        ]);
+    }
+
+    private function getSpans()
+    {
+        $this->tracer->onExit();
+        return $this->tracer->tracer()->spans();
+    }
+
+    public function testRequest()
+    {
+        $elastica = new Client([
+            'host' => self::$elasticHost,
+            'port' => self::$elasticPort
+        ]);
+
+        $request = new Request('_stats', Request::GET, [], [], $elastica->getConnection());
+        $response = $request->send();
+
+        $this->assertInstanceOf(Response::class, $response);
+        $spans = $this->getSpans();
+        $this->assertCount(2, $spans);
+    }
+}

--- a/tests/unit/Trace/Integrations/ElasticaTest.php
+++ b/tests/unit/Trace/Integrations/ElasticaTest.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * Copyright 2019 OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenCensus\Tests\Unit\Trace\Integrations;
+
+
+use OpenCensus\Trace\Integrations\Elastica;
+use OpenCensus\Trace\Span;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @group trace
+ */
+class ElasticaTest extends TestCase
+{
+    public function testHandleConstruct()
+    {
+        $scope = null;
+        $config = [
+            'transport' => 'http',
+            'host' => 'elastic',
+            'port' => '9200',
+        ];
+
+        $spanOptions = Elastica::handleConstruct($scope, $config);
+        $expected = [
+            'attributes' => [
+                'transport' => 'http',
+                'host' => 'elastic',
+                'port' => '9200',
+            ],
+            'kind' => Span::KIND_CLIENT
+        ];
+
+        $this->assertEquals($expected, $spanOptions);
+    }
+
+    public function testHandleRequest()
+    {
+        $scope = null;
+        $path = '/test/path';
+        $method = 'GET';
+        $data = [];
+        $query = [];
+
+        $spanOptions = Elastica::handleRequest($scope, $path, $method, $data, $query);
+        $expected = [
+            'attributes' => [
+                'path' => $path,
+                'method' => $method,
+                'data' => json_encode($data),
+                'query' => json_encode($query),
+            ],
+            'kind' => Span::KIND_CLIENT
+        ];
+
+        $this->assertEquals($expected, $spanOptions);
+    }
+}


### PR DESCRIPTION
Integrating ElasticSearch in the OpenCensus library.

This PR adds support for the following php-elasticsearch clients:

- [x] Ruflin/Elastica