### PR TITLE
Fix Jaeger trace header format

### DIFF
--- a/src/Trace/Propagator/JaegerTraceFormatter.php
+++ b/src/Trace/Propagator/JaegerTraceFormatter.php
@@ -21,7 +21,7 @@ class JaegerTraceFormatter implements FormatterInterface
      *  NOTE ABOUT {parent-span-id}: Deprecated, most Jaeger clients ignore
      *  on the receiving side, but still include it on the sending side
      */
-    const CONTEXT_HEADER_FORMAT = '/(\w+):(\w+):(\d+):(\d)/';
+    const CONTEXT_HEADER_FORMAT = '/(\w+):(\w+):(\w+):(\d)/';
 
     /**
      * Generate a SpanContext object from the Trace Context header


### PR DESCRIPTION
I noticed that when deserializing a valid jaeger header that includes the parent-span-id field, a new spanContext is created.

This is a result of the `preg_match(...)` failing due to the pattern given, since it expects the parent-span-id field to always be numeric, because most jaeger clients ignore it. 

As a solution we can change the pattern to allow words instead of only digits.

`{trace-id}:{span-id}:{parent-span-id}:{flags}`
https://www.jaegertracing.io/docs/1.16/client-libraries/#tracespan-identity