### PR TITLE
PHP 8 Support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,13 +64,13 @@ unit-config: &unit-config
 
     - run:
         name: PHP unit tests
-        command: vendor/bin/phpunit
+        command: XDEBUG_MODE=coverage vendor/bin/phpunit
 
     - run:
         name: PHP unit tests with extension
         command: |
           if [ $RUN_EXTENSION_TESTS -eq "1" ]; then
-            php -d extension=opencensus.so vendor/bin/phpunit
+            XDEBUG_MODE=coverage php -d extension=opencensus.so vendor/bin/phpunit
           else
             echo "Skipping units tests with extension"
           fi
@@ -107,29 +107,30 @@ jobs:
     docker:
       - image: circleci/php:7.3-zts-node
 
-  php71-32bit:
+  php74:
     <<: *unit-config
     docker:
-      - image: gcr.io/php-stackdriver/php71-32bit
-    environment:
-      TEST_PHP_ARGS: -q
-      REPORT_EXIT_STATUS: 1
-      RUN_EXTENSION_TESTS: 1
-      SUDO_CMD: ""
+      - image: circleci/php:7.4-node
 
-  php71-debug:
+  php74-zts:
     <<: *unit-config
     docker:
-      - image: gcr.io/php-stackdriver/php71-debug
-    environment:
-      TEST_PHP_ARGS: -q
-      REPORT_EXIT_STATUS: 1
-      RUN_EXTENSION_TESTS: 1
-      SUDO_CMD: ""
+      - image: circleci/php:7.4-zts-node
 
-  integration:
+  php80:
+    <<: *unit-config
     docker:
-      - image: circleci/php:7.2-node
+      - image: circleci/php:8.0-node
+
+  php80-zts:
+    <<: *unit-config
+    docker:
+      - image: circleci/php:8.0-zts-node
+
+  # Integration tests running on PHP 7.4. When updating these, please also update `integration-8.0` further down.
+  integration-7.4:
+    docker:
+      - image: circleci/php:7.4-node
       - image: memcached
       - image: mysql:5.7
         environment:
@@ -202,14 +203,110 @@ jobs:
       - run:
           name: Pgsql test
           command: tests/integration/pgsql/test.sh
-      - run:
-          name: Symfony 4 test
-          command: tests/integration/symfony4/test.sh
-          environment:
-            DATABASE_URL: mysql://mysql:mysql@127.0.0.1:3306/mysqldb
+# Skipped due to a dependency incompatibility between "cache/adapter-common" and "psr/cache".
+# TODO(mrmage): Re-enable this step once "cache/adapter-common" supports "psr/cache" v2.0/v3.0.
+#      - run:
+#          name: Symfony 4 test
+#          command: tests/integration/symfony4/test.sh
+#          environment:
+#            DATABASE_URL: mysql://mysql:mysql@127.0.0.1:3306/mysqldb
       - run:
           name: Wordpress test
           command: tests/integration/wordpress/test.sh
+    environment:
+      DB_HOST: 127.0.0.1
+      DB_USERNAME: mysql
+      DB_PASSWORD: mysql
+      DB_DATABASE: mysqldb
+
+  # Integration tests running on PHP 8.0. When updating these, please also update `integration-7.4` further down.
+  integration-8.0:
+    docker:
+      - image: circleci/php:8.0-node
+      - image: memcached
+      - image: mysql:5.7
+        environment:
+          MYSQL_USER: mysql
+          MYSQL_PASSWORD: mysql
+          MYSQL_DATABASE: mysqldb
+          MYSQL_RANDOM_ROOT_PASSWORD: yes
+      - image: postgres:9.6
+        environment:
+          POSTGRES_PASSWORD: pgsql
+          POSTGRES_USER: postgres
+    steps:
+      - checkout
+      - run:
+          name: Install build tools
+          command: |
+            sudo apt-get update -y
+            sudo apt-get install -y -q --no-install-recommends \
+              build-essential \
+              g++ \
+              gcc \
+              libc-dev \
+              libpqxx-dev \
+              make \
+              autoconf \
+              git \
+              unzip
+      - run:
+          name: Install opencensus extension
+          command: |
+            cd ext
+            phpize
+            ./configure --enable-opencensus
+            sudo make install
+            sudo docker-php-ext-enable opencensus
+      - run:
+          name: Install memcached extension
+          command: |
+            sudo apt-get install -y -q --no-install-recommends \
+              libmemcached11 libmemcached-dev zlib1g-dev zlib1g
+            sudo pecl install memcached <<<''
+            sudo docker-php-ext-enable memcached
+      - run:
+          name: Install pdo_mysql extension
+          command: sudo docker-php-ext-install pdo_mysql
+      - run:
+          name: Install mysqli extension
+          command: sudo docker-php-ext-install mysqli
+      - run:
+          name: Install pgsql extension
+          command: sudo docker-php-ext-install pgsql
+      - run:
+          name: Install pcntl extension
+          command: sudo docker-php-ext-install pcntl
+      - run:
+          name: Curl test
+          command: tests/integration/curl/test.sh
+      - run:
+          name: Guzzle 5 test
+          command: tests/integration/guzzle5/test.sh
+      - run:
+          name: Guzzle 6 test
+          command: tests/integration/guzzle6/test.sh
+      - run:
+          name: Laravel test
+          command: tests/integration/laravel/test.sh
+      - run:
+          name: Memcached test
+          command: tests/integration/memcached/test.sh
+      - run:
+          name: Pgsql test
+          command: tests/integration/pgsql/test.sh
+# Skipped due to a dependency incompatibility between "cache/adapter-common" and "psr/cache".
+# TODO(mrmage): Re-enable this step once "cache/adapter-common" supports "psr/cache" v2.0/v3.0.
+#      - run:
+#          name: Symfony 4 test
+#          command: tests/integration/symfony4/test.sh
+#          environment:
+#            DATABASE_URL: mysql://mysql:mysql@127.0.0.1:3306/mysqldb
+# Skipped because "wp-cli" is currently not compatible with PHP 8 (see https://github.com/wp-cli/wp-cli/issues/5452).
+# TODO(mrmage): Re-enable this step once "wp-cli" supports PHP 8.
+#      - run:
+#          name: Wordpress test
+#          command: tests/integration/wordpress/test.sh
     environment:
       DB_HOST: 127.0.0.1
       DB_USERNAME: mysql
@@ -226,6 +323,9 @@ workflows:
       - php72-zts
       - php73
       - php73-zts
-      - php71-32bit
-      - php71-debug
-      - integration
+      - php74
+      - php74-zts
+      - php80
+      - php80-zts
+      - integration-7.4
+      - integration-8.0

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -259,6 +259,9 @@ jobs:
         environment:
           POSTGRES_PASSWORD: pgsql
           POSTGRES_USER: postgres
+      - image: redis:4.0
+      - image: elasticsearch:6.8.0
+      - image: mongo:3.6.6
     steps:
       - checkout
       - run:
@@ -302,6 +305,15 @@ jobs:
       - run:
           name: Install pcntl extension
           command: sudo docker-php-ext-install pcntl
+      - run:
+          name: Predis test
+          command: tests/integration/predis/test.sh
+      - run:
+          name: Elastica test
+          command: tests/integration/elastica/test.sh
+      - run:
+          name: MongoDB test
+          command: tests/integration/mongodb/test.sh
       - run:
           name: Curl test
           command: tests/integration/curl/test.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,16 +80,6 @@ unit-config: &unit-config
 
 version: 2
 jobs:
-  php71:
-    <<: *unit-config
-    docker:
-      - image: circleci/php:7.1-node
-
-  php71-zts:
-    <<: *unit-config
-    docker:
-      - image: circleci/php:7.1-zts-node
-
   php72:
     <<: *unit-config
     docker:
@@ -238,13 +228,13 @@ jobs:
       - run:
           name: MongoDB test
           command: tests/integration/mongodb/test.sh
-   environment:
+    environment:
       DB_HOST: 127.0.0.1
       DB_USERNAME: mysql
       DB_PASSWORD: mysql
       DB_DATABASE: mysqldb
 
-  # Integration tests running on PHP 8.0. When updating these, please also update `integration-7.4` further down.
+  # Integration tests running on PHP 8.0.
   integration-8.0:
     docker:
       - image: circleci/php:8.0-node
@@ -306,6 +296,16 @@ jobs:
           name: Install pcntl extension
           command: sudo docker-php-ext-install pcntl
       - run:
+          name: Install redis extension
+          command: |
+            sudo pecl install redis
+            sudo docker-php-ext-enable redis
+      - run:
+          name: Install mongo extension
+          command: |
+            sudo pecl install mongodb
+            sudo docker-php-ext-enable mongodb
+      - run:
           name: Predis test
           command: tests/integration/predis/test.sh
       - run:
@@ -354,8 +354,6 @@ workflows:
   version: 2
   units:
     jobs:
-      - php71
-      - php71-zts
       - php72
       - php72-zts
       - php73

--- a/composer.json
+++ b/composer.json
@@ -16,14 +16,14 @@
     "minimum-stability": "stable",
     "require": {
         "php": ">=7.1",
-        "ramsey/uuid": "~3",
+        "ramsey/uuid": "^3.0 || ^4.0",
         "psr/log": "^1.0",
-        "psr/cache": "^1.0",
+        "psr/cache": "^1.0 || ^2.0 || ^3.0",
         "cache/adapter-common": "^1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.0",
-        "squizlabs/php_codesniffer": "2.*",
+        "phpunit/phpunit": "^7.0 || ^8.0 || ^9.0",
+        "squizlabs/php_codesniffer": "^3.0",
         "twig/twig": "~2.0 || ~1.35",
         "symfony/yaml": "~3.3",
         "guzzlehttp/guzzle": "~5.3",

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     ],
     "minimum-stability": "stable",
     "require": {
-        "php": ">=7.1",
+        "php": ">=7.2",
         "ramsey/uuid": "^3.0 || ^4.0",
         "psr/log": "^1.0",
         "psr/cache": "^1.0 || ^2.0 || ^3.0",
@@ -27,8 +27,8 @@
         "twig/twig": "~2.0 || ~1.35",
         "symfony/yaml": "~3.3",
         "guzzlehttp/guzzle": "~5.3",
-        "ruflin/elastica": "6.0.2",
-        "predis/predis": "1.1.0",
+        "ruflin/elastica": "^7.1",
+        "predis/predis": "^1.1",
         "guzzlehttp/psr7": "~1.4"
     },
     "conflict": {

--- a/examples/symfony/web/app.php
+++ b/examples/symfony/web/app.php
@@ -3,14 +3,8 @@
 use Symfony\Component\HttpFoundation\Request;
 
 require __DIR__.'/../vendor/autoload.php';
-if (PHP_VERSION_ID < 70000) {
-    include_once __DIR__.'/../var/bootstrap.php.cache';
-}
 
 $kernel = new AppKernel('prod', false);
-if (PHP_VERSION_ID < 70000) {
-    $kernel->loadClassCache();
-}
 //$kernel = new AppCache($kernel);
 
 // When using the HttpCache, you need to call the method in your front controller instead of relying on the configuration parameter

--- a/examples/symfony/web/app_dev.php
+++ b/examples/symfony/web/app_dev.php
@@ -22,9 +22,6 @@ require __DIR__.'/../vendor/autoload.php';
 Debug::enable();
 
 $kernel = new AppKernel('dev', true);
-if (PHP_VERSION_ID < 70000) {
-    $kernel->loadClassCache();
-}
 $request = Request::createFromGlobals();
 $response = $kernel->handle($request);
 $response->send();

--- a/ext/opencensus.c
+++ b/ext/opencensus.c
@@ -70,6 +70,10 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_opencensus_trace_add_message_event, 0, 0, 2)
     ZEND_ARG_TYPE_INFO(0, id, IS_STRING, 0)
     ZEND_ARG_ARRAY_INFO(0, options, 0)
 ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_void, 0, 0, 0)
+ZEND_END_ARG_INFO();
+
 /* }}} */
 
 static PHP_MINFO_FUNCTION(opencensus);
@@ -85,16 +89,16 @@ PHP_FUNCTION(opencensus_version);
 /* {{{ opencensus_functions[]
  */
 static zend_function_entry opencensus_functions[] = {
-    PHP_FE(opencensus_version, NULL)
+    PHP_FE(opencensus_version, arginfo_void)
 	PHP_FE(opencensus_core_send_to_daemonclient, arginfo_opencensus_core_send_to_daemon)
     PHP_FE(opencensus_trace_function, arginfo_opencensus_trace_function)
     PHP_FE(opencensus_trace_method, arginfo_opencensus_trace_method)
-    PHP_FE(opencensus_trace_list, NULL)
+    PHP_FE(opencensus_trace_list, arginfo_void)
     PHP_FE(opencensus_trace_begin, arginfo_opencensus_trace_begin)
-    PHP_FE(opencensus_trace_finish, NULL)
-    PHP_FE(opencensus_trace_clear, NULL)
+    PHP_FE(opencensus_trace_finish, arginfo_void)
+    PHP_FE(opencensus_trace_clear, arginfo_void)
     PHP_FE(opencensus_trace_set_context, arginfo_opencensus_trace_set_context)
-    PHP_FE(opencensus_trace_context, NULL)
+    PHP_FE(opencensus_trace_context, arginfo_void)
     PHP_FE(opencensus_trace_add_attribute, arginfo_opencensus_trace_add_attribute)
     PHP_FE(opencensus_trace_add_annotation, arginfo_opencensus_trace_add_annotation)
     PHP_FE(opencensus_trace_add_link, arginfo_opencensus_trace_add_link)
@@ -122,9 +126,6 @@ zend_module_entry opencensus_module_entry = {
 };
 
 #ifdef COMPILE_DL_OPENCENSUS
-#ifdef ZTS
-ZEND_TSRMLS_CACHE_DEFINE()
-#endif
 ZEND_GET_MODULE(opencensus)
 #endif
 
@@ -149,9 +150,6 @@ PHP_MINFO_FUNCTION(opencensus)
  */
 PHP_GINIT_FUNCTION(opencensus)
 {
-#if defined(COMPILE_DL_OPENCENSUS) && defined(ZTS)
-	ZEND_TSRMLS_CACHE_UPDATE()
-#endif
     opencensus_trace_ginit();
 }
 /* }}} */
@@ -168,9 +166,6 @@ PHP_GSHUTDOWN_FUNCTION(opencensus)
  */
 PHP_MINIT_FUNCTION(opencensus)
 {
-#if defined(COMPILE_DL_OPENCENSUS) && defined(ZTS)
-	ZEND_TSRMLS_CACHE_UPDATE()
-#endif
 	REGISTER_INI_ENTRIES();
 
 #ifndef PHP_WIN32

--- a/ext/opencensus_trace.h
+++ b/ext/opencensus_trace.h
@@ -42,8 +42,8 @@ void opencensus_trace_ginit();
 void opencensus_trace_gshutdown();
 void opencensus_trace_rinit();
 void opencensus_trace_rshutdown();
-void opencensus_trace_clear(int reset TSRMLS_DC);
-void opencensus_trace_execute_ex (zend_execute_data *execute_data TSRMLS_DC);
+void opencensus_trace_clear(int reset);
+void opencensus_trace_execute_ex (zend_execute_data *execute_data);
 void opencensus_trace_execute_internal(INTERNAL_FUNCTION_PARAMETERS);
 void span_dtor(zval *zv);
 

--- a/ext/opencensus_trace_annotation.c
+++ b/ext/opencensus_trace_annotation.c
@@ -48,6 +48,9 @@
 
 zend_class_entry* opencensus_trace_annotation_ce = NULL;
 
+ZEND_BEGIN_ARG_INFO_EX(arginfo_void, 0, 0, 0)
+ZEND_END_ARG_INFO();
+
 /**
  * Fetch the annotation description
  *
@@ -60,7 +63,7 @@ static PHP_METHOD(OpenCensusTraceAnnotation, description) {
         return;
     }
 
-    val = zend_read_property(opencensus_trace_annotation_ce, getThis(), "description", sizeof("description") - 1, 1, &rv);
+    val = zend_read_property(opencensus_trace_annotation_ce, OPENCENSUS_OBJ_P(getThis()), "description", sizeof("description") - 1, 1, &rv);
 
     RETURN_ZVAL(val, 1, 0);
 }
@@ -77,7 +80,7 @@ static PHP_METHOD(OpenCensusTraceAnnotation, time) {
         return;
     }
 
-    val = zend_read_property(opencensus_trace_annotation_ce, getThis(), "time", sizeof("time") - 1, 1, &rv);
+    val = zend_read_property(opencensus_trace_annotation_ce, OPENCENSUS_OBJ_P(getThis()), "time", sizeof("time") - 1, 1, &rv);
 
     RETURN_ZVAL(val, 1, 0);
 }
@@ -94,16 +97,16 @@ static PHP_METHOD(OpenCensusTraceAnnotation, options) {
         return;
     }
 
-    val = zend_read_property(opencensus_trace_annotation_ce, getThis(), "options", sizeof("options") - 1, 1, &rv);
+    val = zend_read_property(opencensus_trace_annotation_ce, OPENCENSUS_OBJ_P(getThis()), "options", sizeof("options") - 1, 1, &rv);
 
     RETURN_ZVAL(val, 1, 0);
 }
 
 /* Declare method entries for the OpenCensus\Trace\Ext\Annotation class */
 static zend_function_entry opencensus_trace_annotation_methods[] = {
-    PHP_ME(OpenCensusTraceAnnotation, description, NULL, ZEND_ACC_PUBLIC)
-    PHP_ME(OpenCensusTraceAnnotation, time, NULL, ZEND_ACC_PUBLIC)
-    PHP_ME(OpenCensusTraceAnnotation, options, NULL, ZEND_ACC_PUBLIC)
+    PHP_ME(OpenCensusTraceAnnotation, description, arginfo_void, ZEND_ACC_PUBLIC)
+    PHP_ME(OpenCensusTraceAnnotation, time, arginfo_void, ZEND_ACC_PUBLIC)
+    PHP_ME(OpenCensusTraceAnnotation, options, arginfo_void, ZEND_ACC_PUBLIC)
     PHP_FE_END
 };
 
@@ -115,9 +118,9 @@ int opencensus_trace_annotation_minit(INIT_FUNC_ARGS)
     INIT_CLASS_ENTRY(ce, "OpenCensus\\Trace\\Ext\\Annotation", opencensus_trace_annotation_methods);
     opencensus_trace_annotation_ce = zend_register_internal_class(&ce);
 
-    zend_declare_property_null(opencensus_trace_annotation_ce, "description", sizeof("description") - 1, ZEND_ACC_PROTECTED TSRMLS_CC);
-    zend_declare_property_null(opencensus_trace_annotation_ce, "time", sizeof("time") - 1, ZEND_ACC_PROTECTED TSRMLS_CC);
-    zend_declare_property_null(opencensus_trace_annotation_ce, "options", sizeof("options") - 1, ZEND_ACC_PROTECTED TSRMLS_CC);
+    zend_declare_property_null(opencensus_trace_annotation_ce, "description", sizeof("description") - 1, ZEND_ACC_PROTECTED);
+    zend_declare_property_null(opencensus_trace_annotation_ce, "time", sizeof("time") - 1, ZEND_ACC_PROTECTED);
+    zend_declare_property_null(opencensus_trace_annotation_ce, "options", sizeof("options") - 1, ZEND_ACC_PROTECTED);
 
     return SUCCESS;
 }
@@ -152,8 +155,8 @@ void opencensus_trace_annotation_free(opencensus_trace_annotation_t *annotation)
 int opencensus_trace_annotation_to_zval(opencensus_trace_annotation_t *annotation, zval *zv)
 {
     object_init_ex(zv, opencensus_trace_annotation_ce);
-    zend_update_property_str(opencensus_trace_annotation_ce, zv, "description", sizeof("description") - 1, annotation->description);
-    zend_update_property_double(opencensus_trace_annotation_ce, zv, "time", sizeof("time") - 1, annotation->time_event.time);
-    zend_update_property(opencensus_trace_annotation_ce, zv, "options", sizeof("options") - 1, &annotation->options);
+    zend_update_property_str(opencensus_trace_annotation_ce, OPENCENSUS_OBJ_P(zv), "description", sizeof("description") - 1, annotation->description);
+    zend_update_property_double(opencensus_trace_annotation_ce, OPENCENSUS_OBJ_P(zv), "time", sizeof("time") - 1, annotation->time_event.time);
+    zend_update_property(opencensus_trace_annotation_ce, OPENCENSUS_OBJ_P(zv), "options", sizeof("options") - 1, &annotation->options);
     return SUCCESS;
 }

--- a/ext/opencensus_trace_context.c
+++ b/ext/opencensus_trace_context.c
@@ -43,12 +43,16 @@
  * }
  */
 
+#include "php_opencensus.h"
 #include "opencensus_trace_context.h"
 
 zend_class_entry* opencensus_trace_context_ce = NULL;
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_OpenCensusTraceContext_construct, 0, 0, 1)
 	ZEND_ARG_ARRAY_INFO(0, contextOptions, 0)
+ZEND_END_ARG_INFO();
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_void, 0, 0, 0)
 ZEND_END_ARG_INFO();
 
 /**
@@ -61,12 +65,12 @@ static PHP_METHOD(OpenCensusTraceContext, __construct) {
     zend_string *k;
     HashTable *context_options;
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "h", &context_options) == FAILURE) {
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "h", &context_options) == FAILURE) {
         return;
     }
 
     ZEND_HASH_FOREACH_STR_KEY_VAL(context_options, k, v) {
-        zend_update_property(opencensus_trace_context_ce, getThis(), ZSTR_VAL(k), strlen(ZSTR_VAL(k)), v);
+        zend_update_property(opencensus_trace_context_ce, OPENCENSUS_OBJ_P(getThis()), ZSTR_VAL(k), strlen(ZSTR_VAL(k)), v);
     } ZEND_HASH_FOREACH_END();
 }
 
@@ -82,7 +86,7 @@ static PHP_METHOD(OpenCensusTraceContext, spanId) {
         return;
     }
 
-    val = zend_read_property(opencensus_trace_context_ce, getThis(), "spanId", sizeof("spanId") - 1, 1, &rv);
+    val = zend_read_property(opencensus_trace_context_ce, OPENCENSUS_OBJ_P(getThis()), "spanId", sizeof("spanId") - 1, 1, &rv);
 
     RETURN_ZVAL(val, 1, 0);
 }
@@ -99,7 +103,7 @@ static PHP_METHOD(OpenCensusTraceContext, traceId) {
         return;
     }
 
-    val = zend_read_property(opencensus_trace_context_ce, getThis(), "traceId", sizeof("traceId") - 1, 1, &rv);
+    val = zend_read_property(opencensus_trace_context_ce, OPENCENSUS_OBJ_P(getThis()), "traceId", sizeof("traceId") - 1, 1, &rv);
 
     RETURN_ZVAL(val, 1, 0);
 }
@@ -107,8 +111,8 @@ static PHP_METHOD(OpenCensusTraceContext, traceId) {
 /* Declare method entries for the OpenCensus\Trace\SpanContext class */
 static zend_function_entry opencensus_trace_context_methods[] = {
     PHP_ME(OpenCensusTraceContext, __construct, arginfo_OpenCensusTraceContext_construct, ZEND_ACC_PUBLIC | ZEND_ACC_CTOR)
-    PHP_ME(OpenCensusTraceContext, spanId, NULL, ZEND_ACC_PUBLIC)
-    PHP_ME(OpenCensusTraceContext, traceId, NULL, ZEND_ACC_PUBLIC)
+    PHP_ME(OpenCensusTraceContext, spanId, arginfo_void, ZEND_ACC_PUBLIC)
+    PHP_ME(OpenCensusTraceContext, traceId, arginfo_void, ZEND_ACC_PUBLIC)
     PHP_FE_END
 };
 
@@ -119,8 +123,8 @@ int opencensus_trace_context_minit(INIT_FUNC_ARGS) {
     INIT_CLASS_ENTRY(ce, "OpenCensus\\Trace\\Ext\\SpanContext", opencensus_trace_context_methods);
     opencensus_trace_context_ce = zend_register_internal_class(&ce);
 
-    zend_declare_property_null(opencensus_trace_context_ce, "spanId", sizeof("spanId") - 1, ZEND_ACC_PROTECTED TSRMLS_CC);
-    zend_declare_property_null(opencensus_trace_context_ce, "traceId", sizeof("traceId") - 1, ZEND_ACC_PROTECTED TSRMLS_CC);
+    zend_declare_property_null(opencensus_trace_context_ce, "spanId", sizeof("spanId") - 1, ZEND_ACC_PROTECTED);
+    zend_declare_property_null(opencensus_trace_context_ce, "traceId", sizeof("traceId") - 1, ZEND_ACC_PROTECTED);
 
     return SUCCESS;
 }

--- a/ext/opencensus_trace_link.c
+++ b/ext/opencensus_trace_link.c
@@ -48,6 +48,9 @@
 
 zend_class_entry* opencensus_trace_link_ce = NULL;
 
+ZEND_BEGIN_ARG_INFO_EX(arginfo_void, 0, 0, 0)
+ZEND_END_ARG_INFO();
+
 /**
  * Fetch the link traceId
  *
@@ -60,7 +63,7 @@ static PHP_METHOD(OpenCensusTraceLink, traceId) {
         return;
     }
 
-    val = zend_read_property(opencensus_trace_link_ce, getThis(), "traceId", sizeof("traceId") - 1, 1, &rv);
+    val = zend_read_property(opencensus_trace_link_ce, OPENCENSUS_OBJ_P(getThis()), "traceId", sizeof("traceId") - 1, 1, &rv);
 
     RETURN_ZVAL(val, 1, 0);
 }
@@ -77,7 +80,7 @@ static PHP_METHOD(OpenCensusTraceLink, spanId) {
         return;
     }
 
-    val = zend_read_property(opencensus_trace_link_ce, getThis(), "spanId", sizeof("spanId") - 1, 1, &rv);
+    val = zend_read_property(opencensus_trace_link_ce, OPENCENSUS_OBJ_P(getThis()), "spanId", sizeof("spanId") - 1, 1, &rv);
 
     RETURN_ZVAL(val, 1, 0);
 }
@@ -94,16 +97,16 @@ static PHP_METHOD(OpenCensusTraceLink, options) {
         return;
     }
 
-    val = zend_read_property(opencensus_trace_link_ce, getThis(), "options", sizeof("options") - 1, 1, &rv);
+    val = zend_read_property(opencensus_trace_link_ce, OPENCENSUS_OBJ_P(getThis()), "options", sizeof("options") - 1, 1, &rv);
 
     RETURN_ZVAL(val, 1, 0);
 }
 
 /* Declare method entries for the OpenCensus\Trace\Ext\Link class */
 static zend_function_entry opencensus_trace_link_methods[] = {
-    PHP_ME(OpenCensusTraceLink, traceId, NULL, ZEND_ACC_PUBLIC)
-    PHP_ME(OpenCensusTraceLink, spanId, NULL, ZEND_ACC_PUBLIC)
-    PHP_ME(OpenCensusTraceLink, options, NULL, ZEND_ACC_PUBLIC)
+    PHP_ME(OpenCensusTraceLink, traceId, arginfo_void, ZEND_ACC_PUBLIC)
+    PHP_ME(OpenCensusTraceLink, spanId, arginfo_void, ZEND_ACC_PUBLIC)
+    PHP_ME(OpenCensusTraceLink, options, arginfo_void, ZEND_ACC_PUBLIC)
     PHP_FE_END
 };
 
@@ -115,9 +118,9 @@ int opencensus_trace_link_minit(INIT_FUNC_ARGS)
     INIT_CLASS_ENTRY(ce, "OpenCensus\\Trace\\Ext\\Link", opencensus_trace_link_methods);
     opencensus_trace_link_ce = zend_register_internal_class(&ce);
 
-    zend_declare_property_null(opencensus_trace_link_ce, "traceId", sizeof("traceId") - 1, ZEND_ACC_PROTECTED TSRMLS_CC);
-    zend_declare_property_null(opencensus_trace_link_ce, "spanId", sizeof("spanId") - 1, ZEND_ACC_PROTECTED TSRMLS_CC);
-    zend_declare_property_null(opencensus_trace_link_ce, "options", sizeof("options") - 1, ZEND_ACC_PROTECTED TSRMLS_CC);
+    zend_declare_property_null(opencensus_trace_link_ce, "traceId", sizeof("traceId") - 1, ZEND_ACC_PROTECTED);
+    zend_declare_property_null(opencensus_trace_link_ce, "spanId", sizeof("spanId") - 1, ZEND_ACC_PROTECTED);
+    zend_declare_property_null(opencensus_trace_link_ce, "options", sizeof("options") - 1, ZEND_ACC_PROTECTED);
 
     return SUCCESS;
 }
@@ -155,8 +158,8 @@ void opencensus_trace_link_free(opencensus_trace_link_t *link)
 int opencensus_trace_link_to_zval(opencensus_trace_link_t *link, zval *zv)
 {
     object_init_ex(zv, opencensus_trace_link_ce);
-    zend_update_property_str(opencensus_trace_link_ce, zv, "traceId", sizeof("traceId") - 1, link->trace_id);
-    zend_update_property_str(opencensus_trace_link_ce, zv, "spanId", sizeof("spanId") - 1, link->span_id);
-    zend_update_property(opencensus_trace_link_ce, zv, "options", sizeof("options") - 1, &link->options);
+    zend_update_property_str(opencensus_trace_link_ce, OPENCENSUS_OBJ_P(zv), "traceId", sizeof("traceId") - 1, link->trace_id);
+    zend_update_property_str(opencensus_trace_link_ce, OPENCENSUS_OBJ_P(zv), "spanId", sizeof("spanId") - 1, link->span_id);
+    zend_update_property(opencensus_trace_link_ce, OPENCENSUS_OBJ_P(zv), "options", sizeof("options") - 1, &link->options);
     return SUCCESS;
 }

--- a/ext/opencensus_trace_message_event.c
+++ b/ext/opencensus_trace_message_event.c
@@ -54,6 +54,9 @@
 
 zend_class_entry* opencensus_trace_message_event_ce = NULL;
 
+ZEND_BEGIN_ARG_INFO_EX(arginfo_void, 0, 0, 0)
+ZEND_END_ARG_INFO();
+
 /**
  * Fetch the message_event type
  *
@@ -66,7 +69,7 @@ static PHP_METHOD(OpenCensusTraceMessageEvent, type) {
         return;
     }
 
-    val = zend_read_property(opencensus_trace_message_event_ce, getThis(), "type", sizeof("type") - 1, 1, &rv);
+    val = zend_read_property(opencensus_trace_message_event_ce, OPENCENSUS_OBJ_P(getThis()), "type", sizeof("type") - 1, 1, &rv);
 
     RETURN_ZVAL(val, 1, 0);
 }
@@ -83,7 +86,7 @@ static PHP_METHOD(OpenCensusTraceMessageEvent, id) {
         return;
     }
 
-    val = zend_read_property(opencensus_trace_message_event_ce, getThis(), "id", sizeof("id") - 1, 1, &rv);
+    val = zend_read_property(opencensus_trace_message_event_ce, OPENCENSUS_OBJ_P(getThis()), "id", sizeof("id") - 1, 1, &rv);
 
     RETURN_ZVAL(val, 1, 0);
 }
@@ -100,7 +103,7 @@ static PHP_METHOD(OpenCensusTraceMessageEvent, time) {
         return;
     }
 
-    val = zend_read_property(opencensus_trace_message_event_ce, getThis(), "time", sizeof("time") - 1, 1, &rv);
+    val = zend_read_property(opencensus_trace_message_event_ce, OPENCENSUS_OBJ_P(getThis()), "time", sizeof("time") - 1, 1, &rv);
 
     RETURN_ZVAL(val, 1, 0);
 }
@@ -117,17 +120,17 @@ static PHP_METHOD(OpenCensusTraceMessageEvent, options) {
         return;
     }
 
-    val = zend_read_property(opencensus_trace_message_event_ce, getThis(), "options", sizeof("options") - 1, 1, &rv);
+    val = zend_read_property(opencensus_trace_message_event_ce, OPENCENSUS_OBJ_P(getThis()), "options", sizeof("options") - 1, 1, &rv);
 
     RETURN_ZVAL(val, 1, 0);
 }
 
 /* Declare method entries for the OpenCensus\Trace\Ext\MessageEvent class */
 static zend_function_entry opencensus_trace_message_event_methods[] = {
-    PHP_ME(OpenCensusTraceMessageEvent, type, NULL, ZEND_ACC_PUBLIC)
-    PHP_ME(OpenCensusTraceMessageEvent, id, NULL, ZEND_ACC_PUBLIC)
-    PHP_ME(OpenCensusTraceMessageEvent, time, NULL, ZEND_ACC_PUBLIC)
-    PHP_ME(OpenCensusTraceMessageEvent, options, NULL, ZEND_ACC_PUBLIC)
+    PHP_ME(OpenCensusTraceMessageEvent, type, arginfo_void, ZEND_ACC_PUBLIC)
+    PHP_ME(OpenCensusTraceMessageEvent, id, arginfo_void, ZEND_ACC_PUBLIC)
+    PHP_ME(OpenCensusTraceMessageEvent, time, arginfo_void, ZEND_ACC_PUBLIC)
+    PHP_ME(OpenCensusTraceMessageEvent, options, arginfo_void, ZEND_ACC_PUBLIC)
     PHP_FE_END
 };
 
@@ -139,10 +142,10 @@ int opencensus_trace_message_event_minit(INIT_FUNC_ARGS)
     INIT_CLASS_ENTRY(ce, "OpenCensus\\Trace\\Ext\\MessageEvent", opencensus_trace_message_event_methods);
     opencensus_trace_message_event_ce = zend_register_internal_class(&ce);
 
-    zend_declare_property_null(opencensus_trace_message_event_ce, "type", sizeof("type") - 1, ZEND_ACC_PROTECTED TSRMLS_CC);
-    zend_declare_property_null(opencensus_trace_message_event_ce, "id", sizeof("id") - 1, ZEND_ACC_PROTECTED TSRMLS_CC);
-    zend_declare_property_null(opencensus_trace_message_event_ce, "time", sizeof("time") - 1, ZEND_ACC_PROTECTED TSRMLS_CC);
-    zend_declare_property_null(opencensus_trace_message_event_ce, "options", sizeof("options") - 1, ZEND_ACC_PROTECTED TSRMLS_CC);
+    zend_declare_property_null(opencensus_trace_message_event_ce, "type", sizeof("type") - 1, ZEND_ACC_PROTECTED);
+    zend_declare_property_null(opencensus_trace_message_event_ce, "id", sizeof("id") - 1, ZEND_ACC_PROTECTED);
+    zend_declare_property_null(opencensus_trace_message_event_ce, "time", sizeof("time") - 1, ZEND_ACC_PROTECTED);
+    zend_declare_property_null(opencensus_trace_message_event_ce, "options", sizeof("options") - 1, ZEND_ACC_PROTECTED);
 
     return SUCCESS;
 }
@@ -181,9 +184,9 @@ void opencensus_trace_message_event_free(opencensus_trace_message_event_t *messa
 int opencensus_trace_message_event_to_zval(opencensus_trace_message_event_t *message_event, zval *zv)
 {
     object_init_ex(zv, opencensus_trace_message_event_ce);
-    zend_update_property_str(opencensus_trace_message_event_ce, zv, "type", sizeof("type") - 1, message_event->type);
-    zend_update_property_str(opencensus_trace_message_event_ce, zv, "id", sizeof("id") - 1, message_event->id);
-    zend_update_property_double(opencensus_trace_message_event_ce, zv, "time", sizeof("time") - 1, message_event->time_event.time);
-    zend_update_property(opencensus_trace_message_event_ce, zv, "options", sizeof("options") - 1, &message_event->options);
+    zend_update_property_str(opencensus_trace_message_event_ce, OPENCENSUS_OBJ_P(zv), "type", sizeof("type") - 1, message_event->type);
+    zend_update_property_str(opencensus_trace_message_event_ce, OPENCENSUS_OBJ_P(zv), "id", sizeof("id") - 1, message_event->id);
+    zend_update_property_double(opencensus_trace_message_event_ce, OPENCENSUS_OBJ_P(zv), "time", sizeof("time") - 1, message_event->time_event.time);
+    zend_update_property(opencensus_trace_message_event_ce, OPENCENSUS_OBJ_P(zv), "options", sizeof("options") - 1, &message_event->options);
     return SUCCESS;
 }

--- a/ext/opencensus_trace_span.c
+++ b/ext/opencensus_trace_span.c
@@ -105,6 +105,9 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_OpenCensusTraceSpan_construct, 0, 0, 1)
     ZEND_ARG_ARRAY_INFO(0, spanOptions, 0)
 ZEND_END_ARG_INFO();
 
+ZEND_BEGIN_ARG_INFO_EX(arginfo_void, 0, 0, 0)
+ZEND_END_ARG_INFO();
+
 /**
  * Initializer for OpenCensus\Trace\Span
  *
@@ -112,26 +115,26 @@ ZEND_END_ARG_INFO();
  */
 static PHP_METHOD(OpenCensusTraceSpan, __construct) {
     zval *zval_span_options, *v;
-    ulong idx;
+    unsigned long idx;
     zend_string *k;
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "a", &zval_span_options) == FAILURE) {
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "a", &zval_span_options) == FAILURE) {
         return;
     }
 
     zend_array *span_options = Z_ARR_P(zval_span_options);
     ZEND_HASH_FOREACH_KEY_VAL(span_options, idx, k, v) {
-        zend_update_property(opencensus_trace_span_ce, getThis(), ZSTR_VAL(k), strlen(ZSTR_VAL(k)), v);
+        zend_update_property(opencensus_trace_span_ce, OPENCENSUS_OBJ_P(getThis()), ZSTR_VAL(k), strlen(ZSTR_VAL(k)), v);
     } ZEND_HASH_FOREACH_END();
 }
 
 static PHP_METHOD(OpenCensusTraceSpan, __destruct) {
     zval val, *zv;
-    zv = zend_read_property(opencensus_trace_span_ce, getThis(), "attributes", sizeof("attributes") - 1, 0, &val TSRMLS_CC);
+    zv = zend_read_property(opencensus_trace_span_ce, OPENCENSUS_OBJ_P(getThis()), "attributes", sizeof("attributes") - 1, 0, &val);
     zval_dtor(zv);
-    zv = zend_read_property(opencensus_trace_span_ce, getThis(), "links", sizeof("links") - 1, 0, &val TSRMLS_CC);
+    zv = zend_read_property(opencensus_trace_span_ce, OPENCENSUS_OBJ_P(getThis()), "links", sizeof("links") - 1, 0, &val);
     zval_dtor(zv);
-    zv = zend_read_property(opencensus_trace_span_ce, getThis(), "timeEvents", sizeof("timeEvents") - 1, 0, &val TSRMLS_CC);
+    zv = zend_read_property(opencensus_trace_span_ce, OPENCENSUS_OBJ_P(getThis()), "timeEvents", sizeof("timeEvents") - 1, 0, &val);
     zval_dtor(zv);
 }
 
@@ -147,7 +150,7 @@ static PHP_METHOD(OpenCensusTraceSpan, name) {
         return;
     }
 
-    val = zend_read_property(opencensus_trace_span_ce, getThis(), "name", sizeof("name") - 1, 1, &rv);
+    val = zend_read_property(opencensus_trace_span_ce, OPENCENSUS_OBJ_P(getThis()), "name", sizeof("name") - 1, 1, &rv);
 
     RETURN_ZVAL(val, 1, 0);
 }
@@ -164,7 +167,7 @@ static PHP_METHOD(OpenCensusTraceSpan, spanId) {
         return;
     }
 
-    val = zend_read_property(opencensus_trace_span_ce, getThis(), "spanId", sizeof("spanId") - 1, 1, &rv);
+    val = zend_read_property(opencensus_trace_span_ce, OPENCENSUS_OBJ_P(getThis()), "spanId", sizeof("spanId") - 1, 1, &rv);
 
     RETURN_ZVAL(val, 1, 0);
 }
@@ -181,7 +184,7 @@ static PHP_METHOD(OpenCensusTraceSpan, parentSpanId) {
         return;
     }
 
-    val = zend_read_property(opencensus_trace_span_ce, getThis(), "parentSpanId", sizeof("parentSpanId") - 1, 1, &rv);
+    val = zend_read_property(opencensus_trace_span_ce, OPENCENSUS_OBJ_P(getThis()), "parentSpanId", sizeof("parentSpanId") - 1, 1, &rv);
 
     RETURN_ZVAL(val, 1, 0);
 }
@@ -198,7 +201,7 @@ static PHP_METHOD(OpenCensusTraceSpan, attributes) {
         return;
     }
 
-    val = zend_read_property(opencensus_trace_span_ce, getThis(), "attributes", sizeof("attributes") - 1, 1, &rv);
+    val = zend_read_property(opencensus_trace_span_ce, OPENCENSUS_OBJ_P(getThis()), "attributes", sizeof("attributes") - 1, 1, &rv);
     if (ZVAL_IS_NULL(val)) {
         array_init(return_value);
         return;
@@ -219,7 +222,7 @@ static PHP_METHOD(OpenCensusTraceSpan, links) {
         return;
     }
 
-    val = zend_read_property(opencensus_trace_span_ce, getThis(), "links", sizeof("links") - 1, 1, &rv);
+    val = zend_read_property(opencensus_trace_span_ce, OPENCENSUS_OBJ_P(getThis()), "links", sizeof("links") - 1, 1, &rv);
     if (ZVAL_IS_NULL(val)) {
         array_init(return_value);
         return;
@@ -240,7 +243,7 @@ static PHP_METHOD(OpenCensusTraceSpan, timeEvents) {
         return;
     }
 
-    val = zend_read_property(opencensus_trace_span_ce, getThis(), "timeEvents", sizeof("timeEvents") - 1, 1, &rv);
+    val = zend_read_property(opencensus_trace_span_ce, OPENCENSUS_OBJ_P(getThis()), "timeEvents", sizeof("timeEvents") - 1, 1, &rv);
     if (ZVAL_IS_NULL(val)) {
         array_init(return_value);
         return;
@@ -261,7 +264,7 @@ static PHP_METHOD(OpenCensusTraceSpan, startTime) {
         return;
     }
 
-    val = zend_read_property(opencensus_trace_span_ce, getThis(), "startTime", sizeof("startTime") - 1, 1, &rv);
+    val = zend_read_property(opencensus_trace_span_ce, OPENCENSUS_OBJ_P(getThis()), "startTime", sizeof("startTime") - 1, 1, &rv);
 
     RETURN_ZVAL(val, 1, 0);
 }
@@ -278,7 +281,7 @@ static PHP_METHOD(OpenCensusTraceSpan, endTime) {
         return;
     }
 
-    val = zend_read_property(opencensus_trace_span_ce, getThis(), "endTime", sizeof("endTime") - 1, 1, &rv);
+    val = zend_read_property(opencensus_trace_span_ce, OPENCENSUS_OBJ_P(getThis()), "endTime", sizeof("endTime") - 1, 1, &rv);
 
     RETURN_ZVAL(val, 1, 0);
 }
@@ -295,7 +298,7 @@ static PHP_METHOD(OpenCensusTraceSpan, stackTrace) {
         return;
     }
 
-    val = zend_read_property(opencensus_trace_span_ce, getThis(), "stackTrace", sizeof("stackTrace") - 1, 1, &rv);
+    val = zend_read_property(opencensus_trace_span_ce, OPENCENSUS_OBJ_P(getThis()), "stackTrace", sizeof("stackTrace") - 1, 1, &rv);
     if (ZVAL_IS_NULL(val)) {
         array_init(return_value);
         return;
@@ -316,7 +319,7 @@ static PHP_METHOD(OpenCensusTraceSpan, kind) {
         return;
     }
 
-    val = zend_read_property(opencensus_trace_span_ce, getThis(), "kind", sizeof("kind") - 1, 1, &rv);
+    val = zend_read_property(opencensus_trace_span_ce, OPENCENSUS_OBJ_P(getThis()), "kind", sizeof("kind") - 1, 1, &rv);
 
     RETURN_ZVAL(val, 1, 0);
 }
@@ -333,31 +336,31 @@ static PHP_METHOD(OpenCensusTraceSpan, sameProcessAsParentSpan) {
         return;
     }
 
-    val = zend_read_property(opencensus_trace_span_ce, getThis(), "sameProcessAsParentSpan", sizeof("sameProcessAsParentSpan") - 1, 1, &rv);
+    val = zend_read_property(opencensus_trace_span_ce, OPENCENSUS_OBJ_P(getThis()), "sameProcessAsParentSpan", sizeof("sameProcessAsParentSpan") - 1, 1, &rv);
     switch (Z_TYPE_P(val)) {
         case IS_FALSE:
             RETURN_FALSE;
         case IS_TRUE:
         default:
-            RETURN_TRUE
+            RETURN_TRUE;
     }
 }
 
 /* Declare method entries for the OpenCensus\Trace\Span class */
 static zend_function_entry opencensus_trace_span_methods[] = {
-    PHP_ME(OpenCensusTraceSpan, __construct, arginfo_OpenCensusTraceSpan_construct, ZEND_ACC_PUBLIC | ZEND_ACC_CTOR)
-    PHP_ME(OpenCensusTraceSpan, __destruct, NULL, ZEND_ACC_PUBLIC | ZEND_ACC_DTOR)
-    PHP_ME(OpenCensusTraceSpan, name, NULL, ZEND_ACC_PUBLIC)
-    PHP_ME(OpenCensusTraceSpan, spanId, NULL, ZEND_ACC_PUBLIC)
-    PHP_ME(OpenCensusTraceSpan, parentSpanId, NULL, ZEND_ACC_PUBLIC)
-    PHP_ME(OpenCensusTraceSpan, attributes, NULL, ZEND_ACC_PUBLIC)
-    PHP_ME(OpenCensusTraceSpan, startTime, NULL, ZEND_ACC_PUBLIC)
-    PHP_ME(OpenCensusTraceSpan, endTime, NULL, ZEND_ACC_PUBLIC)
-    PHP_ME(OpenCensusTraceSpan, stackTrace, NULL, ZEND_ACC_PUBLIC)
-    PHP_ME(OpenCensusTraceSpan, links, NULL, ZEND_ACC_PUBLIC)
-    PHP_ME(OpenCensusTraceSpan, timeEvents, NULL, ZEND_ACC_PUBLIC)
-    PHP_ME(OpenCensusTraceSpan, kind, NULL, ZEND_ACC_PUBLIC)
-    PHP_ME(OpenCensusTraceSpan, sameProcessAsParentSpan, NULL, ZEND_ACC_PUBLIC)
+    PHP_ME(OpenCensusTraceSpan, __construct, arginfo_OpenCensusTraceSpan_construct, ZEND_ACC_PUBLIC)
+    PHP_ME(OpenCensusTraceSpan, __destruct, arginfo_void, ZEND_ACC_PUBLIC)
+    PHP_ME(OpenCensusTraceSpan, name, arginfo_void, ZEND_ACC_PUBLIC)
+    PHP_ME(OpenCensusTraceSpan, spanId, arginfo_void, ZEND_ACC_PUBLIC)
+    PHP_ME(OpenCensusTraceSpan, parentSpanId, arginfo_void, ZEND_ACC_PUBLIC)
+    PHP_ME(OpenCensusTraceSpan, attributes, arginfo_void, ZEND_ACC_PUBLIC)
+    PHP_ME(OpenCensusTraceSpan, startTime, arginfo_void, ZEND_ACC_PUBLIC)
+    PHP_ME(OpenCensusTraceSpan, endTime, arginfo_void, ZEND_ACC_PUBLIC)
+    PHP_ME(OpenCensusTraceSpan, stackTrace, arginfo_void, ZEND_ACC_PUBLIC)
+    PHP_ME(OpenCensusTraceSpan, links, arginfo_void, ZEND_ACC_PUBLIC)
+    PHP_ME(OpenCensusTraceSpan, timeEvents, arginfo_void, ZEND_ACC_PUBLIC)
+    PHP_ME(OpenCensusTraceSpan, kind, arginfo_void, ZEND_ACC_PUBLIC)
+    PHP_ME(OpenCensusTraceSpan, sameProcessAsParentSpan, arginfo_void, ZEND_ACC_PUBLIC)
     PHP_FE_END
 };
 
@@ -369,18 +372,18 @@ int opencensus_trace_span_minit(INIT_FUNC_ARGS) {
     opencensus_trace_span_ce = zend_register_internal_class(&ce);
 
     zend_declare_property_string(
-      opencensus_trace_span_ce, "name", sizeof("name") - 1, "unknown", ZEND_ACC_PROTECTED TSRMLS_CC
+      opencensus_trace_span_ce, "name", sizeof("name") - 1, "unknown", ZEND_ACC_PROTECTED
     );
-    zend_declare_property_null(opencensus_trace_span_ce, "spanId", sizeof("spanId") - 1, ZEND_ACC_PROTECTED TSRMLS_CC);
-    zend_declare_property_null(opencensus_trace_span_ce, "parentSpanId", sizeof("parentSpanId") - 1, ZEND_ACC_PROTECTED TSRMLS_CC);
-    zend_declare_property_null(opencensus_trace_span_ce, "startTime", sizeof("startTime") - 1, ZEND_ACC_PROTECTED TSRMLS_CC);
-    zend_declare_property_null(opencensus_trace_span_ce, "endTime", sizeof("endTime") - 1, ZEND_ACC_PROTECTED TSRMLS_CC);
-    zend_declare_property_null(opencensus_trace_span_ce, "attributes", sizeof("attributes") - 1, ZEND_ACC_PROTECTED TSRMLS_CC);
-    zend_declare_property_null(opencensus_trace_span_ce, "stackTrace", sizeof("stackTrace") - 1, ZEND_ACC_PROTECTED TSRMLS_CC);
-    zend_declare_property_null(opencensus_trace_span_ce, "links", sizeof("links") - 1, ZEND_ACC_PROTECTED TSRMLS_CC);
-    zend_declare_property_null(opencensus_trace_span_ce, "timeEvents", sizeof("timeEvents") - 1, ZEND_ACC_PROTECTED TSRMLS_CC);
-    zend_declare_property_null(opencensus_trace_span_ce, "kind", sizeof("kind") - 1, ZEND_ACC_PROTECTED TSRMLS_CC);
-    zend_declare_property_null(opencensus_trace_span_ce, "sameProcessAsParentSpan", sizeof("sameProcessAsParentSpan") - 1, ZEND_ACC_PROTECTED TSRMLS_CC);
+    zend_declare_property_null(opencensus_trace_span_ce, "spanId", sizeof("spanId") - 1, ZEND_ACC_PROTECTED);
+    zend_declare_property_null(opencensus_trace_span_ce, "parentSpanId", sizeof("parentSpanId") - 1, ZEND_ACC_PROTECTED);
+    zend_declare_property_null(opencensus_trace_span_ce, "startTime", sizeof("startTime") - 1, ZEND_ACC_PROTECTED);
+    zend_declare_property_null(opencensus_trace_span_ce, "endTime", sizeof("endTime") - 1, ZEND_ACC_PROTECTED);
+    zend_declare_property_null(opencensus_trace_span_ce, "attributes", sizeof("attributes") - 1, ZEND_ACC_PROTECTED);
+    zend_declare_property_null(opencensus_trace_span_ce, "stackTrace", sizeof("stackTrace") - 1, ZEND_ACC_PROTECTED);
+    zend_declare_property_null(opencensus_trace_span_ce, "links", sizeof("links") - 1, ZEND_ACC_PROTECTED);
+    zend_declare_property_null(opencensus_trace_span_ce, "timeEvents", sizeof("timeEvents") - 1, ZEND_ACC_PROTECTED);
+    zend_declare_property_null(opencensus_trace_span_ce, "kind", sizeof("kind") - 1, ZEND_ACC_PROTECTED);
+    zend_declare_property_null(opencensus_trace_span_ce, "sameProcessAsParentSpan", sizeof("sameProcessAsParentSpan") - 1, ZEND_ACC_PROTECTED);
 
     return SUCCESS;
 }
@@ -632,38 +635,38 @@ static int opencensus_trace_update_links(opencensus_trace_span_t *span, zval *re
 }
 
 /* Fill the provided span with the provided data from the internal span representation */
-int opencensus_trace_span_to_zval(opencensus_trace_span_t *trace_span, zval *span TSRMLS_DC)
+int opencensus_trace_span_to_zval(opencensus_trace_span_t *trace_span, zval *span)
 {
     zval attributes, links, time_events;
     object_init_ex(span, opencensus_trace_span_ce);
-    zend_update_property_str(opencensus_trace_span_ce, span, "spanId", sizeof("spanId") - 1, trace_span->span_id);
+    zend_update_property_str(opencensus_trace_span_ce, OPENCENSUS_OBJ_P(span), "spanId", sizeof("spanId") - 1, trace_span->span_id);
     if (trace_span->parent) {
-        zend_update_property_str(opencensus_trace_span_ce, span, "parentSpanId", sizeof("parentSpanId") - 1, trace_span->parent->span_id);
+        zend_update_property_str(opencensus_trace_span_ce, OPENCENSUS_OBJ_P(span), "parentSpanId", sizeof("parentSpanId") - 1, trace_span->parent->span_id);
     } else if (OPENCENSUS_G(trace_parent_span_id)) {
-        zend_update_property_str(opencensus_trace_span_ce, span, "parentSpanId", sizeof("parentSpanId") - 1, OPENCENSUS_G(trace_parent_span_id));
+        zend_update_property_str(opencensus_trace_span_ce, OPENCENSUS_OBJ_P(span), "parentSpanId", sizeof("parentSpanId") - 1, OPENCENSUS_G(trace_parent_span_id));
     }
-    zend_update_property_str(opencensus_trace_span_ce, span, "name", sizeof("name") - 1, trace_span->name);
-    zend_update_property_double(opencensus_trace_span_ce, span, "startTime", sizeof("startTime") - 1, trace_span->start);
-    zend_update_property_double(opencensus_trace_span_ce, span, "endTime", sizeof("endTime") - 1, trace_span->stop);
+    zend_update_property_str(opencensus_trace_span_ce, OPENCENSUS_OBJ_P(span), "name", sizeof("name") - 1, trace_span->name);
+    zend_update_property_double(opencensus_trace_span_ce, OPENCENSUS_OBJ_P(span), "startTime", sizeof("startTime") - 1, trace_span->start);
+    zend_update_property_double(opencensus_trace_span_ce, OPENCENSUS_OBJ_P(span), "endTime", sizeof("endTime") - 1, trace_span->stop);
 
     array_init(&attributes);
     zend_hash_copy(Z_ARRVAL(attributes), trace_span->attributes, zval_add_ref);
-    zend_update_property(opencensus_trace_span_ce, span, "attributes", sizeof("attributes") - 1, &attributes);
+    zend_update_property(opencensus_trace_span_ce, OPENCENSUS_OBJ_P(span), "attributes", sizeof("attributes") - 1, &attributes);
 
-    zend_update_property(opencensus_trace_span_ce, span, "stackTrace", sizeof("stackTrace") - 1, &trace_span->stackTrace);
+    zend_update_property(opencensus_trace_span_ce, OPENCENSUS_OBJ_P(span), "stackTrace", sizeof("stackTrace") - 1, &trace_span->stackTrace);
 
     array_init(&links);
     opencensus_trace_update_links(trace_span, &links);
-    zend_update_property(opencensus_trace_span_ce, span, "links", sizeof("links") - 1, &links);
+    zend_update_property(opencensus_trace_span_ce, OPENCENSUS_OBJ_P(span), "links", sizeof("links") - 1, &links);
 
     array_init(&time_events);
     opencensus_trace_update_time_events(trace_span, &time_events);
-    zend_update_property(opencensus_trace_span_ce, span, "timeEvents", sizeof("timeEvents") - 1, &time_events);
+    zend_update_property(opencensus_trace_span_ce, OPENCENSUS_OBJ_P(span), "timeEvents", sizeof("timeEvents") - 1, &time_events);
 
     if (trace_span->kind) {
-        zend_update_property_str(opencensus_trace_span_ce, span, "kind", sizeof("kind") - 1, trace_span->kind);
+        zend_update_property_str(opencensus_trace_span_ce, OPENCENSUS_OBJ_P(span), "kind", sizeof("kind") - 1, trace_span->kind);
     }
-    zend_update_property_bool(opencensus_trace_span_ce, span, "sameProcessAsParentSpan", sizeof("sameProcessAsParentSpan") - 1, trace_span->same_process_as_parent_span);
+    zend_update_property_bool(opencensus_trace_span_ce, OPENCENSUS_OBJ_P(span), "sameProcessAsParentSpan", sizeof("sameProcessAsParentSpan") - 1, trace_span->same_process_as_parent_span);
 
     return SUCCESS;
 }

--- a/ext/package.xml
+++ b/ext/package.xml
@@ -12,11 +12,11 @@ This extension allows you to easily gather latency and other metadata by watchin
   <email>chingor@google.com</email>
   <active>yes</active>
  </lead>
- <date>2018-05-08</date>
- <time>16:17:00</time>
+ <date>2021-06-08</date>
+ <time>15:57:00</time>
  <version>
-  <release>0.2.2</release>
-  <api>0.2.2</api>
+  <release>0.3.0</release>
+  <api>0.3.0</api>
  </version>
  <stability>
   <release>alpha</release>
@@ -24,18 +24,24 @@ This extension allows you to easily gather latency and other metadata by watchin
  </stability>
  <license>Apache 2.0</license>
  <notes>
-- Fix refcounts for arguments in traced function callbacks (#184)
+- OpenCensus stats implementation (#220)
+- Fix ZVAL_DESTRUCTOR usage
+- Add PHP8 compatibility (#270)
  </notes>
  <contents>
   <dir baseinstalldir="/" name="/">
    <file baseinstalldir="/" name="config.m4" role="src" />
    <file baseinstalldir="/" name="config.w32" role="src" />
+   <file baseinstalldir="/" name="opencensus.c" role="src" />
+   <file baseinstalldir="/" name="opencensus_core_daemonclient.c" role="src" />
    <file baseinstalldir="/" name="opencensus_trace.c" role="src" />
    <file baseinstalldir="/" name="opencensus_trace_annotation.c" role="src" />
    <file baseinstalldir="/" name="opencensus_trace_context.c" role="src" />
    <file baseinstalldir="/" name="opencensus_trace_link.c" role="src" />
    <file baseinstalldir="/" name="opencensus_trace_message_event.c" role="src" />
    <file baseinstalldir="/" name="opencensus_trace_span.c" role="src" />
+   <file baseinstalldir="/" name="varint.c" role="src" />
+   <file baseinstalldir="/" name="opencensus_core_daemonclient.h" role="src" />
    <file baseinstalldir="/" name="opencensus_trace.h" role="src" />
    <file baseinstalldir="/" name="opencensus_trace_annotation.h" role="src" />
    <file baseinstalldir="/" name="opencensus_trace_context.h" role="src" />
@@ -44,6 +50,7 @@ This extension allows you to easily gather latency and other metadata by watchin
    <file baseinstalldir="/" name="opencensus_trace_span.h" role="src" />
    <file baseinstalldir="/" name="opencensus_trace_time_event.h" role="src" />
    <file baseinstalldir="/" name="php_opencensus.h" role="src" />
+   <file baseinstalldir="/" name="varint.h" role="src" />
 
    <file name="README.md" role="doc" />
    <file name="LICENSE" role="doc" />
@@ -51,7 +58,6 @@ This extension allows you to easily gather latency and other metadata by watchin
    <dir name="tests">
     <file name="common.inc" role="test" />
     <file name="annotations.phpt" role="test" />
-    <file name="backtrace_test.phpt" role="test" />
     <file name="basic_class_function.phpt" role="test" />
     <file name="basic_context.phpt" role="test" />
     <file name="basic_function.phpt" role="test" />
@@ -74,7 +80,6 @@ This extension allows you to easily gather latency and other metadata by watchin
     <file name="function_callback_wrong_return.phpt" role="test" />
     <file name="function_custom.phpt" role="test" />
     <file name="inherit_context.phpt" role="test" />
-    <file name="int_start_time.phpt" role="test" />
     <file name="labels.phpt" role="test" />
     <file name="links.phpt" role="test" />
     <file name="manual_spans.phpt" role="test" />
@@ -90,17 +95,35 @@ This extension allows you to easily gather latency and other metadata by watchin
     <file name="method_callback_string.phpt" role="test" />
     <file name="method_custom.phpt" role="test" />
     <file name="module_callback_static_string.phpt" role="test" />
+    <file name="name_castable_object.phpt" role="test" />
+    <file name="name_double.phpt" role="test" />
+    <file name="name_integer.phpt" role="test" />
+    <file name="name_null.phpt" role="test" />
+    <file name="name_uncastable_object.phpt" role="test" />
+    <file name="name_uncastable_object_php74.phpt" role="test" />
     <file name="nested_spans.phpt" role="test" />
     <file name="non-string-labels-function-callback.phpt" role="test" />
     <file name="non-string-labels-function.phpt" role="test" />
     <file name="non-string-labels-method-callback.phpt" role="test" />
     <file name="non-string-labels-method.phpt" role="test" />
     <file name="non-string-labels.phpt" role="test" />
-    <file name="null_start_time.phpt" role="test" />
     <file name="span_class.phpt" role="test" />
+    <file name="span_id_double.phpt" role="test" />
+    <file name="span_id_integer.phpt" role="test" />
+    <file name="span_id_null.phpt" role="test" />
+    <file name="span_id_string.phpt" role="test" />
     <file name="span_kind.phpt" role="test" />
+    <file name="span_kind_integer.phpt" role="test" />
+    <file name="span_kind_null.phpt" role="test" />
     <file name="span_same_process_as_parent_span.phpt" role="test" />
-    <file name="span_specify_id.phpt" role="test" />
+    <file name="span_same_process_as_parent_span_falsy.phpt" role="test" />
+    <file name="span_stacktrace_custom.phpt" role="test" />
+    <file name="span_stacktrace_default.phpt" role="test" />
+    <file name="span_stacktrace_invalid.phpt" role="test" />
+    <file name="span_start_time_double.phpt" role="test" />
+    <file name="span_start_time_int.phpt" role="test" />
+    <file name="span_start_time_null.phpt" role="test" />
+    <file name="span_start_time_string.phpt" role="test" />
     <file name="static_method_callback_scope.phpt" role="test" />
     <file name="static_method_test.phpt" role="test" />
     <file name="trace_context.phpt" role="test" />
@@ -306,6 +329,23 @@ Fix handling startTime when passed to opencensus_trace_begin (#135)
    <license>Apache 2.0</license>
    <notes>
 - Fix refcounts for arguments in traced function callbacks (#184)
+   </notes>
+  </release>
+  <release>
+   <version>
+    <release>0.3.0</release>
+    <api>0.3.0</api>
+   </version>
+   <stability>
+    <release>alpha</release>
+    <api>alpha</api>
+   </stability>
+   <date>2021-06-08</date>
+   <license>Apache 2.0</license>
+   <notes>
+- OpenCensus stats implementation (#220)
+- Fix ZVAL_DESTRUCTOR usage
+- Add PHP8 compatibility (#270)
    </notes>
   </release>
  </changelog>

--- a/ext/package.xml
+++ b/ext/package.xml
@@ -133,7 +133,7 @@ This extension allows you to easily gather latency and other metadata by watchin
  <dependencies>
   <required>
    <php>
-    <min>7.0.0</min>
+    <min>7.1.0</min>
    </php>
    <pearinstaller>
     <min>1.4.0</min>

--- a/ext/php_opencensus.h
+++ b/ext/php_opencensus.h
@@ -31,7 +31,7 @@
 #include <sys/time.h>
 #endif
 
-#define PHP_OPENCENSUS_VERSION "0.7.0"
+#define PHP_OPENCENSUS_VERSION "0.3.0"
 #define PHP_OPENCENSUS_EXTNAME "opencensus"
 
 extern zend_module_entry opencensus_module_entry;

--- a/ext/php_opencensus.h
+++ b/ext/php_opencensus.h
@@ -31,7 +31,7 @@
 #include <sys/time.h>
 #endif
 
-#define PHP_OPENCENSUS_VERSION "0.3.0"
+#define PHP_OPENCENSUS_VERSION "0.7.0"
 #define PHP_OPENCENSUS_EXTNAME "opencensus"
 
 extern zend_module_entry opencensus_module_entry;
@@ -52,6 +52,13 @@ ZEND_END_MODULE_GLOBALS(opencensus)
 
 ZEND_EXTERN_MODULE_GLOBALS(opencensus)
 #define OPENCENSUS_G(v) ZEND_MODULE_GLOBALS_ACCESSOR(opencensus, v)
+
+// Compatibility macro to account for a few method signature changes in PHP 8.
+#if PHP_MAJOR_VERSION < 8
+#define OPENCENSUS_OBJ_P(v) (v)
+#else
+#define OPENCENSUS_OBJ_P(v) Z_OBJ_P(v)
+#endif
 
 double opencensus_now();
 

--- a/ext/releases.yaml
+++ b/ext/releases.yaml
@@ -89,3 +89,12 @@ releases:
     stability: alpha
     notes: |-
       - Fix refcounts for arguments in traced function callbacks (#184)
+
+  - date: '2021-06-08'
+    time: 15:57:00
+    version: 0.3.0
+    stability: alpha
+    notes: |-
+      - OpenCensus stats implementation (#220)
+      - Fix ZVAL_DESTRUCTOR usage
+      - Add PHP8 compatibility (#270)

--- a/ext/tests/name_uncastable_object.phpt
+++ b/ext/tests/name_uncastable_object.phpt
@@ -1,5 +1,9 @@
 --TEST--
 OpenCensus Trace: Providing integer as name
+--SKIPIF--
+<?php
+if (version_compare(phpversion(), '7.4', '>=')) die("skip this test is for PHP versions < 7.4; see name_uncastable_object_php74.phpt for the PHP 7.4+ equivalent");
+?>
 --FILE--
 <?php
 

--- a/ext/tests/name_uncastable_object_php74.phpt
+++ b/ext/tests/name_uncastable_object_php74.phpt
@@ -1,0 +1,30 @@
+--TEST--
+OpenCensus Trace: Providing integer as name
+--SKIPIF--
+<?php
+if (version_compare(phpversion(), '7.4', '<')) die("skip this test is for PHP versions >= 7.4; see name_uncastable_object_php74.phpt for the PHP 7.4+ equivalent");
+?>
+--FILE--
+<?php
+
+class UncastableObject
+{
+    private $value = 'my value';
+}
+
+$obj = new UncastableObject();
+opencensus_trace_begin('foo', ['name' => $obj]);
+opencensus_trace_finish();
+$spans = opencensus_trace_list();
+
+echo 'Number of spans: ' . count($spans) . PHP_EOL;
+$span = $spans[0];
+var_dump($span->name());
+
+?>
+--EXPECTF--
+Fatal error: Uncaught Error: Object of class UncastableObject could not be converted to string in %sname_uncastable_object_php74.php:%d
+Stack trace:
+#0 %sname_uncastable_object_php74.php(%d): opencensus_trace_begin('foo', Array)
+#1 {main}
+  thrown in %sname_uncastable_object_php74.php on line %d

--- a/src/Trace/Propagator/CloudTraceFormatter.php
+++ b/src/Trace/Propagator/CloudTraceFormatter.php
@@ -101,7 +101,7 @@ class CloudTraceFormatter implements FormatterInterface
         $result = '';
 
         for ($i = 0; $i < $length; $i++) {
-            $number[$i] = strpos($chars, $numstring{$i});
+            $number[$i] = strpos($chars, $numstring[$i]);
         }
 
         do {
@@ -117,7 +117,7 @@ class CloudTraceFormatter implements FormatterInterface
                 }
             }
             $length = $newlen;
-            $result = $newstring{$divide} . $result;
+            $result = $newstring[$divide] . $result;
         } while ($newlen != 0);
 
         return $result;

--- a/tests/integration/curl/composer.json
+++ b/tests/integration/curl/composer.json
@@ -1,11 +1,11 @@
 {
     "require": {
-        "php": "^7.2",
+        "php": ">=7.1",
         "opencensus/opencensus": "dev-master",
         "ext-opencensus": "*"
     },
     "require-dev": {
-        "phpunit/phpunit": "^7.0"
+        "phpunit/phpunit": "^9.0"
     },
     "repositories": [
         {

--- a/tests/integration/curl/tests/CurlTest.php
+++ b/tests/integration/curl/tests/CurlTest.php
@@ -27,12 +27,12 @@ use PHPUnit\Framework\TestCase;
  */
 class CurlTest extends TestCase
 {
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         Curl::load();
     }
 
-    public function setUp()
+    protected function setUp(): void
     {
         if (!extension_loaded('opencensus')) {
             $this->markTestSkipped('Please enable the opencensus extension.');

--- a/tests/integration/elastica/composer.json
+++ b/tests/integration/elastica/composer.json
@@ -1,12 +1,12 @@
 {
     "require": {
-        "php": "^7.2",
+        "php": "^7.2|^8.0",
         "opencensus/opencensus": "dev-master",
-        "ruflin/elastica": "6.0.2",
+        "ruflin/elastica": "^7.1",
         "ext-opencensus": "*"
     },
     "require-dev": {
-        "phpunit/phpunit": "^7.0"
+        "phpunit/phpunit": "^8.0|^9.0"
     },
     "repositories": [
         {

--- a/tests/integration/elastica/tests/ElasticaTest.php
+++ b/tests/integration/elastica/tests/ElasticaTest.php
@@ -16,14 +16,14 @@ class ElasticaTest extends TestCase
     private static $elasticHost;
     private static $elasticPort;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         Elastica::load();
         self::$elasticHost = getenv('ELASTIC_HOST') ?: '127.0.0.1';
         self::$elasticPort = (int) (getenv('ELASTIC_PORT') ?: 9200);
     }
 
-    public function setUp()
+    public function setUp(): void
     {
         if (!extension_loaded('opencensus')) {
             $this->markTestSkipped('Please enable the opencensus extension.');

--- a/tests/integration/guzzle5/composer.json
+++ b/tests/integration/guzzle5/composer.json
@@ -1,12 +1,12 @@
 {
     "require": {
-        "php": "^7.2",
+        "php": ">=7.1",
         "opencensus/opencensus": "dev-master",
         "guzzlehttp/guzzle": "^5.0",
         "ext-opencensus": "*"
     },
     "require-dev": {
-        "phpunit/phpunit": "^7.0",
+        "phpunit/phpunit": "^9.0",
         "jcchavezs/httptest": "~0.2"
     },
     "repositories": {

--- a/tests/integration/guzzle5/tests/Guzzle5Test.php
+++ b/tests/integration/guzzle5/tests/Guzzle5Test.php
@@ -33,9 +33,8 @@ class Guzzle5Test extends TestCase
 {
     private $client;
 
-    public function setUp()
+    protected function setUp(): void
     {
-        parent::setUp();
         $this->client = new Client();
         $subscriber = new EventSubscriber();
         $this->client->getEmitter()->attach($subscriber);

--- a/tests/integration/guzzle6/composer.json
+++ b/tests/integration/guzzle6/composer.json
@@ -1,12 +1,12 @@
 {
     "require": {
-        "php": "^7.2",
+        "php": ">=7.1",
         "opencensus/opencensus": "dev-master",
         "guzzlehttp/guzzle": "^6.0",
         "ext-opencensus": "*"
     },
     "require-dev": {
-        "phpunit/phpunit": "^7.0",
+        "phpunit/phpunit": "^9.0",
         "jcchavezs/httptest": "~0.2"
     },
     "repositories": {

--- a/tests/integration/guzzle6/tests/Guzzle6Test.php
+++ b/tests/integration/guzzle6/tests/Guzzle6Test.php
@@ -34,9 +34,8 @@ class Guzzle6Test extends TestCase
 {
     private $client;
 
-    public function setUp()
+    protected function setUp(): void
     {
-        parent::setUp();
         $stack = new HandlerStack();
         $stack->setHandler(\GuzzleHttp\choose_handler());
         $stack->push(new Middleware());

--- a/tests/integration/laravel/test.sh
+++ b/tests/integration/laravel/test.sh
@@ -25,7 +25,7 @@ pushd laravel
 
 composer config repositories.opencensus git ${REPO}
 composer require opencensus/opencensus:dev-${BRANCH}
-composer require --dev phpunit/phpunit:^9.0 guzzlehttp/guzzle:~6.0
+composer require --dev phpunit/phpunit:^9.0
 
 php artisan migrate
 vendor/bin/phpunit

--- a/tests/integration/laravel/test.sh
+++ b/tests/integration/laravel/test.sh
@@ -25,10 +25,10 @@ pushd laravel
 
 composer config repositories.opencensus git ${REPO}
 composer require opencensus/opencensus:dev-${BRANCH}
-composer require --dev phpunit/phpunit:^7.0 guzzlehttp/guzzle:~6.0
+composer require --dev phpunit/phpunit:^9.0 guzzlehttp/guzzle:~6.0
 
 php artisan migrate
-vendor/bin/phpunit --config=phpunit.xml.dist
+vendor/bin/phpunit
 
 popd
 popd

--- a/tests/integration/laravel/tests/integration/LaravelTest.php
+++ b/tests/integration/laravel/tests/integration/LaravelTest.php
@@ -25,7 +25,7 @@ class LaravelTest extends TestCase
     private static $outputFile;
     private static $client;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         self::$outputFile = sys_get_temp_dir() . '/spans.json';
         self::$client = new Client([
@@ -33,9 +33,8 @@ class LaravelTest extends TestCase
         ]);
     }
 
-    public function setUp()
+    protected function setUp(): void
     {
-        parent::setUp();
         $this->clearSpans();
     }
 

--- a/tests/integration/memcached/composer.json
+++ b/tests/integration/memcached/composer.json
@@ -1,12 +1,12 @@
 {
     "require": {
-        "php": "^7.2",
+        "php": ">=7.1",
         "opencensus/opencensus": "dev-master",
         "ext-opencensus": "*",
         "ext-memcached": "*"
     },
     "require-dev": {
-        "phpunit/phpunit": "^7.0"
+        "phpunit/phpunit": "^9.0"
     },
     "repositories": [
         {

--- a/tests/integration/memcached/tests/MemcachedTest.php
+++ b/tests/integration/memcached/tests/MemcachedTest.php
@@ -29,14 +29,14 @@ class MemcachedTest extends TestCase
     private static $memcachedHost;
     private static $memcachedPort;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         MemcachedIntegration::load();
         self::$memcachedHost = getenv('MEMCACHED_HOST') ?: '127.0.0.1';
         self::$memcachedPort = (int) (getenv('MEMCACHED_PORT') ?: 11211);
     }
 
-    public function setUp()
+    protected function setUp(): void
     {
         if (!extension_loaded('opencensus')) {
             $this->markTestSkipped('Please enable the opencensus extension.');

--- a/tests/integration/mongodb/composer.json
+++ b/tests/integration/mongodb/composer.json
@@ -1,12 +1,12 @@
 {
   "require": {
-    "php": "^7.2",
+    "php": "^7.2|^8.0",
     "opencensus/opencensus": "dev-master",
     "ext-opencensus": "*",
     "ext-mongodb": "*"
   },
   "require-dev": {
-    "phpunit/phpunit": "^7.0",
+    "phpunit/phpunit": "^8.0|^9.0",
     "mongodb/mongodb": "1.3.2"
   },
   "repositories": [

--- a/tests/integration/mongodb/tests/MongoDBTest.php
+++ b/tests/integration/mongodb/tests/MongoDBTest.php
@@ -31,12 +31,12 @@ class MongoDBTest extends TestCase
 
     private $tracer;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         MongoDB::load();
     }
 
-    public function setUp()
+    public function setUp(): void
     {
         if (!extension_loaded('opencensus')) {
             $this->markTestSkipped('Please enable the opencensus extension.');

--- a/tests/integration/pgsql/composer.json
+++ b/tests/integration/pgsql/composer.json
@@ -1,12 +1,12 @@
 {
     "require": {
-        "php": "^7.2",
+        "php": ">=7.1",
         "opencensus/opencensus": "dev-master",
         "ext-opencensus": "*",
         "ext-pgsql": "*"
     },
     "require-dev": {
-        "phpunit/phpunit": "^7.0"
+        "phpunit/phpunit": "^9.0"
     },
     "repositories": [
         {

--- a/tests/integration/pgsql/tests/PgsqlTest.php
+++ b/tests/integration/pgsql/tests/PgsqlTest.php
@@ -27,7 +27,7 @@ class PgsqlTest extends TestCase
     private $tracer;
     private static $postgresConnectionString;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         Postgres::load();
         $postgresHost = getenv('POSTGRES_HOST') ?: '127.0.0.1';
@@ -46,7 +46,7 @@ class PgsqlTest extends TestCase
         );
     }
 
-    public function setUp()
+    protected function setUp(): void
     {
         if (!extension_loaded('opencensus')) {
             $this->markTestSkipped('Please enable the opencensus extension.');

--- a/tests/integration/predis/composer.json
+++ b/tests/integration/predis/composer.json
@@ -1,13 +1,13 @@
 {
     "require": {
-        "php": "^7.2",
+        "php": "^7.2|^8.0",
         "opencensus/opencensus": "dev-master",
         "predis/predis": "1.1.0",
         "ext-opencensus": "*",
         "ext-redis": "*"
     },
     "require-dev": {
-        "phpunit/phpunit": "^7.0"
+        "phpunit/phpunit": "^8.0|^9.0"
     },
     "repositories": [
         {

--- a/tests/integration/predis/tests/PredisTest.php
+++ b/tests/integration/predis/tests/PredisTest.php
@@ -29,14 +29,14 @@ class PredisTest extends TestCase
     private static $redisHost;
     private static $redisPort;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         RedisIntegration::load();
         self::$redisHost = getenv('REDIS_HOST') ?: '127.0.0.1';
         self::$redisPort = (int) (getenv('REDIS_PORT') ?: 6379);
     }
 
-    public function setUp()
+    public function setUp(): void
     {
         if (!extension_loaded('opencensus')) {
             $this->markTestSkipped('Please enable the opencensus extension.');

--- a/tests/integration/symfony4/test.sh
+++ b/tests/integration/symfony4/test.sh
@@ -25,7 +25,7 @@ pushd symfony
 
 composer config repositories.opencensus git ${REPO}
 composer require opencensus/opencensus:dev-${BRANCH} doctrine
-composer require --dev phpunit/phpunit:^7.0 guzzlehttp/guzzle:~6.0
+composer require --dev phpunit/phpunit:^9.0 guzzlehttp/guzzle:~6.0
 
 bin/console doctrine:migrations:migrate -n
 vendor/bin/phpunit

--- a/tests/integration/symfony4/tests/SymfonyTest.php
+++ b/tests/integration/symfony4/tests/SymfonyTest.php
@@ -25,7 +25,7 @@ class SymfonyTest extends TestCase
     private static $outputFile;
     private static $client;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         self::$outputFile = sys_get_temp_dir() . '/spans.json';
         self::$client = new Client([
@@ -33,9 +33,8 @@ class SymfonyTest extends TestCase
         ]);
     }
 
-    public function setUp()
+    protected function setUp(): void
     {
-        parent::setUp();
         $this->clearSpans();
     }
 

--- a/tests/integration/wordpress/composer.json
+++ b/tests/integration/wordpress/composer.json
@@ -1,12 +1,12 @@
 {
     "require": {
-        "php": "^7.2",
+        "php": ">=7.1",
         "opencensus/opencensus": "dev-master",
         "ext-opencensus": "*"
     },
     "require-dev": {
         "wp-cli/wp-cli": "~1.1",
-        "phpunit/phpunit": "^7.0",
+        "phpunit/phpunit": "^9.0",
         "guzzlehttp/guzzle": "~6.0"
     },
     "repositories": [

--- a/tests/integration/wordpress/tests/integration/WordpressTest.php
+++ b/tests/integration/wordpress/tests/integration/WordpressTest.php
@@ -24,14 +24,13 @@ class WordpressTest extends TestCase
 {
     private static $outputFile;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         self::$outputFile = sys_get_temp_dir() . '/spans.json';
     }
 
-    public function setUp()
+    protected function setUp(): void
     {
-        parent::setUp();
         if (file_exists(self::$outputFile)) {
             $fp = fopen(self::$outputFile, 'r+');
             ftruncate($fp, 0);
@@ -49,7 +48,7 @@ class WordpressTest extends TestCase
             ]
         ]);
         $this->assertEquals(200, $response->getStatusCode());
-        $this->assertContains('Hello world!', $response->getBody()->getContents());
+        $this->assertStringContainsString('Hello world!', $response->getBody()->getContents());
 
         $spans = json_decode(file_get_contents(self::$outputFile), true);
         $this->assertNotEmpty($spans);

--- a/tests/unit/Core/ContextTest.php
+++ b/tests/unit/Core/ContextTest.php
@@ -25,14 +25,15 @@ use PHPUnit\Framework\TestCase;
  */
 class ContextTest extends TestCase
 {
-    public function setUp()
+    protected function setUp(): void
     {
         Context::reset();
     }
 
-    public function tearDown()
+    protected function tearDown(): void
     {
         Context::reset();
+        parent::tearDown();
     }
 
     public function testBackgroundGeneratesEmptyContext()
@@ -68,11 +69,10 @@ class ContextTest extends TestCase
         $this->assertEquals($initialContext, Context::current());
     }
 
-    /**
-     * @expectedException PHPUnit_Framework_Error_Warning
-     */
     public function testRestoringCurrentContextRequiresSameObject()
     {
+        $this->expectException(\PHPUnit\Framework\Error\Warning::class);
+
         $context = new Context(['foo' => 'bar']);
         $prevContext = $context->attach();
 

--- a/tests/unit/Core/ScopeTest.php
+++ b/tests/unit/Core/ScopeTest.php
@@ -27,7 +27,7 @@ class ScopeTest extends TestCase
 {
     private $data;
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->data = [];
     }

--- a/tests/unit/Trace/Exporter/FileExporterTest.php
+++ b/tests/unit/Trace/Exporter/FileExporterTest.php
@@ -29,14 +29,15 @@ class FileExporterTest extends TestCase
     private $tracer;
     private $filename;
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->filename = tempnam(sys_get_temp_dir(), 'traces');
     }
 
-    public function tearDown()
+    protected function tearDown(): void
     {
         @unlink($this->filename);
+        parent::tearDown();
     }
 
     public function testLogsTrace()

--- a/tests/unit/Trace/Exporter/LoggerExporterTest.php
+++ b/tests/unit/Trace/Exporter/LoggerExporterTest.php
@@ -33,7 +33,7 @@ class LoggerExporterTest extends TestCase
     private $tracer;
     private $logger;
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->logger = $this->prophesize(LoggerInterface::class);
     }

--- a/tests/unit/Trace/Integrations/Guzzle/EventSubscriberTest.php
+++ b/tests/unit/Trace/Integrations/Guzzle/EventSubscriberTest.php
@@ -35,7 +35,7 @@ class EventSubscriberTest extends TestCase
 {
     private $exporter;
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->exporter = $this->prophesize(ExporterInterface::class);
         if (extension_loaded('opencensus')) {

--- a/tests/unit/Trace/Integrations/Guzzle/MiddlewareTest.php
+++ b/tests/unit/Trace/Integrations/Guzzle/MiddlewareTest.php
@@ -33,7 +33,7 @@ class MiddlewareTest extends TestCase
 {
     private $exporter;
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->exporter = $this->prophesize(ExporterInterface::class);
         if (extension_loaded('opencensus')) {

--- a/tests/unit/Trace/Propagator/BinaryFormatterTest.php
+++ b/tests/unit/Trace/Propagator/BinaryFormatterTest.php
@@ -49,11 +49,10 @@ class BinaryFormatterTest extends TestCase
         $this->assertEquals($hex, bin2hex($formatter->serialize($context)));
     }
 
-    /**
-     * @expectedException PHPUnit_Framework_Error_Warning
-     */
     public function testDeserializeBadData()
     {
+        $this->expectException(\PHPUnit\Framework\Error\Warning::class);
+
         $formatter = new BinaryFormatter();
         $context = $formatter->deserialize(hex2bin("0012341abc"));
     }

--- a/tests/unit/Trace/RequestHandlerTest.php
+++ b/tests/unit/Trace/RequestHandlerTest.php
@@ -43,7 +43,7 @@ class RequestHandlerTest extends TestCase
 
     private $sampler;
 
-    public function setUp()
+    protected function setUp(): void
     {
         if (extension_loaded('opencensus')) {
             opencensus_trace_clear();

--- a/tests/unit/Trace/Sampler/ProbabilitySamplerTest.php
+++ b/tests/unit/Trace/Sampler/ProbabilitySamplerTest.php
@@ -27,10 +27,11 @@ class ProbabilitySamplerTest extends TestCase
 {
     /**
      * @dataProvider invalidRates
-     * @expectedException \InvalidArgumentException
      */
     public function testInvalidRate($rate)
     {
+        $this->expectException(\InvalidArgumentException::class);
+        
         $sampler = new ProbabilitySampler($rate);
     }
 

--- a/tests/unit/Trace/Sampler/QpsSamplerTest.php
+++ b/tests/unit/Trace/Sampler/QpsSamplerTest.php
@@ -63,10 +63,11 @@ class QpsSamplerTest extends TestCase
 
     /**
      * @dataProvider invalidRates
-     * @expectedException \InvalidArgumentException
      */
     public function testInvalidRate($rate)
     {
+        $this->expectException(\InvalidArgumentException::class);
+        
         $cache = $this->prophesize(CacheItemPoolInterface::class);
         $sampler = new QpsSampler($cache->reveal(), [
             'rate' => $rate

--- a/tests/unit/Trace/SpanDataTest.php
+++ b/tests/unit/Trace/SpanDataTest.php
@@ -85,7 +85,7 @@ class SpanDataTest extends TestCase
         ]);
 
         $hashId = $spanData->stackTraceHashId();
-        $this->assertInternalType('string', $hashId);
+        $this->assertIsString($hashId);
         $this->assertEquals($hashId, $spanData2->stackTraceHashId());
     }
 }

--- a/tests/unit/Trace/SpanTest.php
+++ b/tests/unit/Trace/SpanTest.php
@@ -101,7 +101,7 @@ class SpanTest extends TestCase
         $span = new Span();
 
         $stackTrace = $span->spanData()->stackTrace();
-        $this->assertInternalType('array', $stackTrace);
+        $this->assertIsArray($stackTrace);
         $this->assertNotEmpty($stackTrace);
         $stackframe = $stackTrace[0];
         $this->assertEquals('testGeneratesBacktrace', $stackframe['function']);

--- a/tests/unit/Trace/Tracer/AbstractTracerTest.php
+++ b/tests/unit/Trace/Tracer/AbstractTracerTest.php
@@ -278,7 +278,7 @@ abstract class AbstractTracerTest extends TestCase
         $this->assertCount(1, $spans);
         $spanData = $spans[0];
 
-        $this->assertInternalType('array', $spanData->stackTrace());
+        $this->assertIsArray($spanData->stackTrace());
         $this->assertNotEmpty($spanData->stackTrace());
     }
 
@@ -294,7 +294,7 @@ abstract class AbstractTracerTest extends TestCase
         $this->assertCount(1, $spans);
         $spanData = $spans[0];
 
-        $this->assertInternalType('array', $spanData->attributes());
+        $this->assertIsArray($spanData->attributes());
         $this->assertEmpty($spanData->attributes());
     }
 
@@ -310,7 +310,7 @@ abstract class AbstractTracerTest extends TestCase
         $this->assertCount(1, $spans);
         $spanData = $spans[0];
 
-        $this->assertInternalType('array', $spanData->links());
+        $this->assertIsArray($spanData->links());
         $this->assertEmpty($spanData->links());
     }
 
@@ -326,7 +326,7 @@ abstract class AbstractTracerTest extends TestCase
         $this->assertCount(1, $spans);
         $spanData = $spans[0];
 
-        $this->assertInternalType('array', $spanData->timeEvents());
+        $this->assertIsArray($spanData->timeEvents());
         $this->assertEmpty($spanData->timeEvents());
     }
 

--- a/tests/unit/Trace/Tracer/ContextTracerTest.php
+++ b/tests/unit/Trace/Tracer/ContextTracerTest.php
@@ -25,7 +25,7 @@ use OpenCensus\Trace\Tracer\ContextTracer;
  */
 class ContextTracerTest extends AbstractTracerTest
 {
-    public function setUp()
+    protected function setUp(): void
     {
         Context::reset();
     }

--- a/tests/unit/Trace/Tracer/ExtentionTracerTest.php
+++ b/tests/unit/Trace/Tracer/ExtentionTracerTest.php
@@ -24,7 +24,7 @@ use OpenCensus\Trace\Tracer\ExtensionTracer;
  */
 class ExtensionTracerTest extends AbstractTracerTest
 {
-    public function setUp()
+    protected function setUp(): void
     {
         if (!extension_loaded('opencensus')) {
             $this->markTestSkipped('Must have the opencensus extension installed to run this test.');

--- a/tests/unit/Trace/TracerTest.php
+++ b/tests/unit/Trace/TracerTest.php
@@ -31,7 +31,7 @@ class TracerTest extends TestCase
 {
     private $reporter;
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->reporter = $this->prophesize(ExporterInterface::class);
     }


### PR DESCRIPTION
- Merge `census-instrumentation/opencensus-php` master branch that already supports PHP8.
- Update circleci config
- Upgrade ruflin/elastica:^7.1 in orde to support PHP 8